### PR TITLE
Fixed bug with excel_sort_columns function

### DIFF
--- a/ClointFusion/ClointFusion.py
+++ b/ClointFusion/ClointFusion.py
@@ -2195,8 +2195,9 @@ def excel_sort_columns(excel_path="",sheet_name='Sheet1',header=0,firstColumnToB
         elif firstColumnToBeSorted is not None:
             df=df.sort_values([firstColumnToBeSorted],ascending=[firstColumnSortType])
 
+        book = load_workbook(excel_path)
         writer = pd.ExcelWriter(excel_path, engine='openpyxl') # pylint: disable=abstract-class-instantiated
-        writer.book = load_workbook(excel_path)
+        writer.book = book
         writer.sheets = dict((ws.title, ws) for ws in writer.book.worksheets)
     
         df.to_excel(writer,sheet_name=sheet_name,index=False)


### PR DESCRIPTION
Fixed the "badzipFile : File is not a Zip file" issue in the excel_sort_columns function.

Reference used : [How to write to an existing excel file without overwriting data (using pandas)?](https://stackoverflow.com/questions/20219254/how-to-write-to-an-existing-excel-file-without-overwriting-data-using-pandas)