### PR TITLE
Fixed Bugs with browser_mouse_click_h() function

### DIFF
--- a/ClointFusion/ClointFusion.py
+++ b/ClointFusion/ClointFusion.py
@@ -3495,7 +3495,7 @@ def browser_mouse_click_h(User_Visible_Text_Element="",element="d",below='',to_r
             User_Visible_Text_Element = gui_get_any_input_from_user("visible text element (button/link/checkbox/radio etc) to Click")
 
         if User_Visible_Text_Element and element.lower()=="d":      #default
-            click(User_Visible_Text_Element,below=below,to_right_of=to_right_of,above=above,to_left_of=to_left_of)
+            click(User_Visible_Text_Element)
         elif User_Visible_Text_Element and element.lower()=="l":    #link
             click(link(User_Visible_Text_Element,below=below,to_right_of=to_right_of,above=above,to_left_of=to_left_of))
         elif User_Visible_Text_Element and element.lower()=="b":    #button

--- a/ClointFusion/ClointFusion.py
+++ b/ClointFusion/ClointFusion.py
@@ -3497,7 +3497,7 @@ def browser_mouse_click_h(User_Visible_Text_Element="",element="d",below='',to_r
         if User_Visible_Text_Element and element.lower()=="d":      #default
             click(User_Visible_Text_Element)
         elif User_Visible_Text_Element and element.lower()=="l":    #link
-            click(link(User_Visible_Text_Element,below=below,to_right_of=to_right_of,above=above,to_left_of=to_left_of))
+            click(Link(User_Visible_Text_Element,below=below,to_right_of=to_right_of,above=above,to_left_of=to_left_of))
         elif User_Visible_Text_Element and element.lower()=="b":    #button
             click(Button(User_Visible_Text_Element,below=below,to_right_of=to_right_of,above=above,to_left_of=to_left_of))
         elif User_Visible_Text_Element and element.lower()=="t":    #textfield


### PR DESCRIPTION
This PR contains two commits.

1. The `click()` from helium functions don't have additional parameters like _below, to_right_of, above & to_left_of_ . Those were removed from browser_mouse_click_h().

2. There is difference between `link` & `Link` in helium. Both are different. 

For Reference: [API - helium Docs](https://selenium-python-helium.readthedocs.io/en/latest/api.html#helium.click)