### PR TITLE
change pandasgui to tabloo

### DIFF
--- a/ClointFusion/ClointFusion.py
+++ b/ClointFusion/ClointFusion.py
@@ -56,7 +56,7 @@ from selenium.common.exceptions import SessionNotCreatedException
 from selenium.webdriver.chrome.options import Options
 from chromedriver_py import binary_path
 import pyinspect as pi
-from pandasgui import show
+from tabloo import show
 
 os_name = str(platform.system()).lower()
 sg.theme('Dark') # for PySimpleGUI FRONT END        

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ pyinspect>= 0.0.8
 pyfiglet
 pillow>= 8.2.0
 qtstylish>=0.1.0 
-pandasgui>= 0.2.10.1
+tabloo >= 0.0.15
 xls2xlsx >= 0.1.4
 xlwt >= 1.2.0
 psutil >= 5.8.0


### PR DESCRIPTION
pandasgui requires wordcloud which requires additional software to be installed in latest python 3.9 version.
Tabloo is alternative which uses flask as backend and opens gui in a default browser with localhost. we can filter, save plots, etc.
pandasgui syntax and tabloo syntax is pretty much same. and we used only show in our code so this single change is enough.
This is not a advanced tool like pandasgui but saves a lot of time and makes accessing clointfusion easier.

![Tabloo_Screenshot_Table](https://user-images.githubusercontent.com/67296473/123321883-2c771100-d551-11eb-92a5-3eaff771f9cf.png)
![Tabloo_Screenshot_plot](https://user-images.githubusercontent.com/67296473/123321890-300a9800-d551-11eb-8a9d-a97cffe9a9ef.png)
